### PR TITLE
added user offset correction block

### DIFF
--- a/iis3dwb_reg.c
+++ b/iis3dwb_reg.c
@@ -555,6 +555,50 @@ int32_t iis3dwb_temp_flag_data_ready_get(stmdev_ctx_t *ctx,
 }
 
 /**
+  * @brief  Enables the accelerometer user offset correction block, can be enabled 
+  * by setting the USR_OFF_ON_OUT bit of the CTRL7_C register.[set]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of USR_OFF_ON_OUT in reg CTRL7_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_usr_offset_block_set(stmdev_ctx_t *ctx, uint8_t val)
+{
+  iis3dwb_ctrl7_c_t ctrl7_c;
+
+  int32_t ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL7_C, (uint8_t *)&ctrl7_c, 1);
+
+  if (ret == 0)
+  {
+    ctrl7_c.usr_off_on_out = (uint8_t)val;
+    ret = iis3dwb_write_reg(ctx, IIS3DWB_CTRL7_C,
+                            (uint8_t *)&ctrl7_c, 1);
+  }
+
+  return ret;
+}
+
+/**
+  * @brief  Enables the accelerometer user offset correction block, can be enabled 
+  * by setting the USR_OFF_ON_OUT bit of the CTRL7_C register.[get]
+  *
+  * @param  ctx    Read / write interface definitions.(ptr)
+  * @param  val    Change the values of USR_OFF_ON_OUT in reg CTRL7_C
+  * @retval        Interface status (MANDATORY: return 0 -> no Error).
+  *
+  */
+int32_t iis3dwb_usr_offset_block_get(stmdev_ctx_t *ctx, uint8_t *val)
+{
+  iis3dwb_ctrl7_c_t ctrl7_c;
+
+  const int32_t ret = iis3dwb_read_reg(ctx, IIS3DWB_CTRL7_C, (uint8_t *)&ctrl7_c, 1);
+  *val = ctrl7_c.usr_off_on_out;
+
+  return ret;
+}
+
+/**
   * @brief  Accelerometer X-axis user offset correction expressed in two’s
   *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
   *         The value must be in the range [-127 127].[set]

--- a/iis3dwb_reg.h
+++ b/iis3dwb_reg.h
@@ -410,6 +410,19 @@ typedef struct
   uint8_t xl_axis_sel              : 2;
 #endif /* DRV_BYTE_ORDER */
 } iis3dwb_ctrl6_c_t;
+#define IIS3DWB_CTRL7_C                      0x16U
+typedef struct
+{
+#if DRV_BYTE_ORDER == DRV_LITTLE_ENDIAN
+  uint8_t not_used_01               : 1;
+  uint8_t usr_off_on_out            : 1;
+  uint8_t not_used_02               : 6;
+#elif DRV_BYTE_ORDER == DRV_BIG_ENDIAN
+  uint8_t not_used_02               : 6;
+  uint8_t usr_off_on_out            : 1;
+  uint8_t not_used_01               : 1;
+#endif /* DRV_BYTE_ORDER */
+} iis3dwb_ctrl7_c_t;
 
 #define IIS3DWB_CTRL8_XL                     0x17U
 typedef struct
@@ -695,6 +708,7 @@ typedef union
   iis3dwb_ctrl4_c_t                       ctrl4_c;
   iis3dwb_ctrl5_c_t                       ctrl5_c;
   iis3dwb_ctrl6_c_t                       ctrl6_c;
+  iis3dwb_ctrl7_c_t                       ctrl7_c;
   iis3dwb_ctrl8_xl_t                      ctrl8_xl;
   iis3dwb_ctrl10_c_t                      ctrl10_c;
   iis3dwb_all_int_src_t                   all_int_src;
@@ -816,6 +830,9 @@ int32_t iis3dwb_xl_flag_data_ready_get(stmdev_ctx_t *ctx,
 
 int32_t iis3dwb_temp_flag_data_ready_get(stmdev_ctx_t *ctx,
                                          uint8_t *val);
+
+int32_t iis3dwb_usr_offset_block_set(stmdev_ctx_t *ctx, uint8_t val);
+int32_t iis3dwb_usr_offset_block_get(stmdev_ctx_t *ctx, uint8_t *val);
 
 int32_t iis3dwb_xl_usr_offset_x_set(stmdev_ctx_t *ctx, uint8_t *buff);
 int32_t iis3dwb_xl_usr_offset_x_get(stmdev_ctx_t *ctx, uint8_t *buff);


### PR DESCRIPTION
The current version lib (latest commit version) does not implement the accelerometer user offset correction block feature, that can be enabled by setting the USR_OFF_ON_OUT bit of the CTRL7_C register and is mandatory in order to be able to apply offset correction.

this pull request implements the following: 

From Application note (AN5444) IIS3DWB: ultrawide bandwidth, low-noise, 3-axis digital vibration sensor:
"The device provides accelerometer offset registers (X_OFS_USR, Y_OFS_USR, Z_OFS_USR) which can be
used for zero-g offset correction or, in general, to apply an offset to the accelerometer output data.
The accelerometer offset block can be enabled by setting the USR_OFF_ON_OUT bit of the CTRL7_C register. The offset value set in the offset registers is internally subtracted from the measured acceleration value for the respective axis; internally processed data are then sent to the accelerometer output register and to the FIFO (if enabled). These register values are expressed as an 8-bit word in two’s complement and must be in the range [-127, 127].
The weight [g/LSB] to be applied to the offset register values is independent of the accelerometer selected full scale and can be configured using the USR_OFF_W bit of the CTRL6_C register:
• 2-10 g/LSB if the USR_OFF_W bit is set to 0.
• 2-6 g/LSB if the USR_OFF_W bit is set to 1."


in "iis3dwb_reg.c" file:
func "iis3dwb_usr_offset_block_set":
 Enables the accelerometer user offset correction block, can be enabled 
 by setting the USR_OFF_ON_OUT bit of the CTRL7_C register.[set]
 
func "iis3dwb_usr_offset_block_get":
 Get Status of the accelerometer user offset correction block, can be done
 by getting the USR_OFF_ON_OUT bit of the CTRL7_C register.[get]
 
 in "iis3dwb_reg.h" file:
IIS3DWB_CTRL7 register map and definitions
 