### PR TITLE
const qualify parameters

### DIFF
--- a/iis3dwb_reg.c
+++ b/iis3dwb_reg.c
@@ -1815,7 +1815,7 @@ int32_t iis3dwb_i2c_interface_get(const stmdev_ctx_t *ctx,
   *
   */
 int32_t iis3dwb_pin_int1_route_set(const stmdev_ctx_t *ctx,
-                                   iis3dwb_pin_int1_route_t *val)
+                                   const iis3dwb_pin_int1_route_t *val)
 {
   iis3dwb_int1_ctrl_t          int1_ctrl;
   iis3dwb_slope_en_t           slope_en;
@@ -1908,7 +1908,7 @@ int32_t iis3dwb_pin_int1_route_get(const stmdev_ctx_t *ctx,
   *
   */
 int32_t iis3dwb_pin_int2_route_set(const stmdev_ctx_t *ctx,
-                                   iis3dwb_pin_int2_route_t *val)
+                                   const iis3dwb_pin_int2_route_t *val)
 {
   iis3dwb_int2_ctrl_t          int2_ctrl;
   iis3dwb_slope_en_t           slope_en;

--- a/iis3dwb_reg.h
+++ b/iis3dwb_reg.h
@@ -988,7 +988,7 @@ uint8_t sleep_change  :
   uint8_t sleep_status  : 1; /* Act/Inact status */
 } iis3dwb_pin_int1_route_t;
 int32_t iis3dwb_pin_int1_route_set(const stmdev_ctx_t *ctx,
-                                   iis3dwb_pin_int1_route_t *val);
+                                   const iis3dwb_pin_int1_route_t *val);
 int32_t iis3dwb_pin_int1_route_get(const stmdev_ctx_t *ctx,
                                    iis3dwb_pin_int1_route_t *val);
 
@@ -1006,7 +1006,7 @@ typedef struct
   uint8_t sleep_status  : 1; /* Act/Inact status */
 } iis3dwb_pin_int2_route_t;
 int32_t iis3dwb_pin_int2_route_set(const stmdev_ctx_t *ctx,
-                                   iis3dwb_pin_int2_route_t *val);
+                                   const iis3dwb_pin_int2_route_t *val);
 int32_t iis3dwb_pin_int2_route_get(const stmdev_ctx_t *ctx,
                                    iis3dwb_pin_int2_route_t *val);
 


### PR DESCRIPTION
const qualify a couple of parameters to fix warnings of source code static analysis with cppcheck

@avisconti can you review this, please?